### PR TITLE
feat: allow container to run with a read-only rootfs (INFRA-2967)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,7 @@ RUN mkdir -p /var/cache/nginx /var/log/nginx /var/run/nginx \
 
 USER nginx
 
+# Directive VOLUME must be placed after the directories creation to allow conservation of the ownership
+VOLUME ["/var/run/nginx", "/var/log/nginx", "/var/cache/nginx"]
+
 EXPOSE 8080/tcp

--- a/cst.yml
+++ b/cst.yml
@@ -3,6 +3,7 @@ metadataTest:
   entrypoint: ["/docker-entrypoint.sh"]
   cmd: ["nginx", "-g", "daemon off;"]
   exposedPorts: ["8080"]
+  volumes: ["/var/log/nginx", "/var/run/nginx", "/var/cache/nginx"]
 fileExistenceTests:
   - name: 'nginx'
     path: '/usr/sbin/nginx'


### PR DESCRIPTION
Signed-off-by: Damien Duportal <damien.duportal@gmail.com>

- https://issues.jenkins.io/browse/INFRA-2967
- Works out of the box with `docker run --read-only --rm -d -P <image>`
- On Kubernetes, you might want to mount the 3 "volumes" to emptyDir Kubernetes Volumes