### PR TITLE
fix: catch invalid host names in the default vhost

### DIFF
--- a/conf.d/default.conf
+++ b/conf.d/default.conf
@@ -1,6 +1,6 @@
 server {
     listen       8080;
-    server_name  default_server;
+    server_name _ default_server;
 
     location / {
         root   /usr/share/nginx/html;


### PR DESCRIPTION
Adding "_" to catch all requests invalid hosts

See http://nginx.org/en/docs/http/server_names.html (search for "strange" in this page)