### PR TITLE
chore: temporarilly using the pipeline library from the PR 333 for testing purpose

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,1 +1,3 @@
+@Library('pipeline-library@pull/333/head') _
+
 parallelDockerUpdatecli([imageName: '404', rebuildImageOnPeriodicJob: false, containerMemory: '1G'])


### PR DESCRIPTION
as per #helpdesk2837 
just to try the new version of the pipeline shared library.