### PR TITLE
Revert "chore: temporarilly using the pipeline library from the PR 333 for testing purpose"

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,3 +1,1 @@
-@Library('pipeline-library@pull/333/head') _
-
 parallelDockerUpdatecli([imageName: '404', rebuildImageOnPeriodicJob: false, containerMemory: '1G'])


### PR DESCRIPTION
Reverts jenkins-infra/docker-404#21

as it worked (docker image have been published : https://hub.docker.com/r/jenkinsciinfra/404/tags), we can revert the changes 