### PR TITLE
chore(jenkinsfile_k8s):Build and deploy tags only on principal branch builds

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,1 +1,3 @@
-parallelDockerUpdatecli([imageName: '404', rebuildImageOnPeriodicJob: false, , updatecliConfig: [containerMemory: '1G'], buildDockerConfig : [targetplatforms: 'linux/amd64,linux/arm64']])
+@Library('pipeline-library@pull/924/head') _
+
+buildDockerAndPublishImage('404', [targetplatforms: 'linux/amd64,linux/arm64'])


### PR DESCRIPTION
as per - https://github.com/jenkins-infra/pipeline-library/issues/918

We want to build 2 Docker images: `latest` and `XXX` only when we merge a PR on the principal branch. In order to make it a single step process, to avoid hitting Github API rate limits; we are removing tag triggered builds (currently a two step process)