### PR TITLE
chore(jenkinsfile_k8s): Enable automaticSemanticVersioning

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,3 +1,6 @@
 @Library('pipeline-library@pull/924/head') _
 
-buildDockerAndPublishImage('404', [targetplatforms: 'linux/amd64,linux/arm64'])
+buildDockerAndPublishImage('404', [
+    automaticSemanticVersioning: true,
+    targetplatforms: 'linux/amd64,linux/arm64',
+    ])


### PR DESCRIPTION
Related to - https://github.com/jenkins-infra/pipeline-library/issues/918

We enable `automaticSemanticVersioning` to check if the pipeline creates and deploys both `latest` and `xxx` docker images on the <principal branch>.