### PR TITLE
chore(Jenkinsfile_k8s): Remove automaticSemanticVersioning from script call

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,4 +1,3 @@
 buildDockerAndPublishImage('404', [
-    automaticSemanticVersioning: true,
     targetplatforms: 'linux/amd64,linux/arm64',
     ])


### PR DESCRIPTION
As per - https://github.com/jenkins-infra/helpdesk/issues/2778

`automaticSemanticVersioning` is set to true by default, we no longer need to set the parameter in the script call.