### PR TITLE
test(jenkinsfile_k8s) enable cache-to parameter to build docker images

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,3 +1,6 @@
+@Library('pipeline-library@pull/940/head') _
+
 buildDockerAndPublishImage('404', [
     targetplatforms: 'linux/amd64,linux/arm64',
-    ])
+    cacheTo: 'type=inline' // Added cacheTo parameter
+])


### PR DESCRIPTION
This PR tests `cache-to` enabled in `buildDockerAndPublishImage`

Ref: https://github.com/jenkins-infra/docker-404/pull/46