### PR TITLE
test(jenkinsfile_k8s) enable cache-to parameter to build docker images on main branch

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,3 +1,7 @@
+@Library('pipeline-library@pull/944/head') _
+
 buildDockerAndPublishImage('404', [
     targetplatforms: 'linux/amd64,linux/arm64',
-    ])
+    registryNamespace: 'jenkinsciinfra',
+    cacheTo: 'type=registry,ref=jenkinsciinfra/404:latest-cache'
+])

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -2,6 +2,5 @@
 
 buildDockerAndPublishImage('404', [
     targetplatforms: 'linux/amd64,linux/arm64',
-    registryNamespace: 'jenkinsciinfra',
-    cacheTo: 'type=registry,ref=jenkinsciinfra/404:latest-cache'
+    cacheTo: 'type=registry,ref=jenkinsciinfra/404:latest-cache',
 ])


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/pipeline-library/pull/944

Related to https://github.com/jenkins-infra/helpdesk/issues/4683

This PR test non-regression of the new `cacheTo` feature on PR builds and `cacheTo` enabled once merged to `main`